### PR TITLE
time.clock() is deprecated. Changed to time.process_time()

### DIFF
--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -3283,7 +3283,7 @@ def checkEqual(lst):
 
 
 def getPath4axis(context, operation):
-    t = time.clock()
+    t = time.process_time()
     s = bpy.context.scene
     o = operation
     getBounds(o)
@@ -3422,7 +3422,7 @@ def rotTo2axes(e, axescombination):
 
 
 def getPath(context, operation):  # should do all path calculations.
-    t = time.clock()
+    t = time.process_time()
     # print('ahoj0')
     if shapely.speedups.available:
         shapely.speedups.enable()
@@ -3470,7 +3470,7 @@ def getPath(context, operation):  # should do all path calculations.
         exportGcodePath(operation.filename, [p.data], [operation])
 
     operation.changed = False
-    t1 = time.clock() - t
+    t1 = time.process_time() - t
     progress('total time', t1)
 
 


### PR DESCRIPTION
time.clock is deprecated since python 3.3. It's not avail. in python 3.8.
Tested in Manjaro with python 3.8. Also successful tested with 3.6. Should also work with older python3 versions.