### PR TITLE
Fix: Modifier stack not applied for pocket strategy.

### DIFF
--- a/scripts/addons/cam/utils.py
+++ b/scripts/addons/cam/utils.py
@@ -1221,7 +1221,7 @@ def getOperationSilhouete(operation):
         # this conversion happens because we need the silh to be oriented, for milling directions.
         else:
             print('object method for retrieving silhouette')  #
-            operation.silhouete = getObjectSilhouete(stype, objects=operation.objects)
+            operation.silhouete = getObjectSilhouete(stype, objects=operation.objects, use_modifiers=operation.use_modifiers)
 
         operation.update_silhouete_tag = False
     return operation.silhouete
@@ -1246,9 +1246,9 @@ def getObjectSilhouete(stype, objects=None, use_modifiers=False):
             print('shapely getting silhouette')
             polys = []
             for ob in objects:
-
                 if use_modifiers:
-                    m = ob.to_mesh(preserve_all_data_layers=True, depsgraph=bpy.context.evaluated_depsgraph_get())
+                    ob = ob.evaluated_get(bpy.context.evaluated_depsgraph_get())
+                    m = ob.to_mesh()
                 else:
                     m = ob.data
                 mw = ob.matrix_world
@@ -1282,9 +1282,7 @@ def getObjectSilhouete(stype, objects=None, use_modifiers=False):
                         # if id==923:
                         #	m.polygons[923].select
                         id += 1
-                if use_modifiers:
-                    bpy.data.meshes.remove(m)
-            # print(polys
+   
             if totfaces < 20000:
                 p = sops.unary_union(polys)
             else:


### PR DESCRIPTION
I had a problem creating a pocketing operation on a object with a modifier stack
![object-with-modifiers](https://user-images.githubusercontent.com/77103970/117586320-cb69ba00-b117-11eb-9fc3-8022aea565d2.png)
. It seemed the toolpath was only generated for the objects mesh without the modifiers applied
![wrong-toolpath](https://user-images.githubusercontent.com/77103970/117586321-cc9ae700-b117-11eb-8bfd-aaf004e16e3a.png)
. What I like to see and what I could achieve by this PR is:
![fixed-toolpath](https://user-images.githubusercontent.com/77103970/117586319-cad12380-b117-11eb-9469-93f6ed7fa4e7.png)

### My System
Blender: 2.92.0 on Windows 10 x64

### Problem
It tourns out the `use_modifiers` option was not passed on. I also could not get it to work with the already existing code in `getObjectSilhouete` for that case.

BTW ❤️ this project!