### PR TITLE
Fix issue with deleted object while using collection of objects

### DIFF
--- a/scripts/addons/cam/ops.py
+++ b/scripts/addons/cam/ops.py
@@ -210,8 +210,13 @@ class CalculatePath(bpy.types.Operator):
         # getIslands(context.object)
         s = bpy.context.scene
         o = s.cam_operations[s.cam_active_operation]
-        ob = bpy.data.objects[o.object_name]
-        ob.hide_set(False)
+        if o.geometry_source=='OBJECT':
+            ob = bpy.data.objects[o.object_name]
+            ob.hide_set(False)
+        if o.geometry_source=='COLLECTION':
+            obc = bpy.data.collections[o.collection_name]
+            for ob in obc.objects:
+                ob.hide_set(False)
         if o.strategy=="CARVE":
             curvob=bpy.data.objects[o.curve_object]
             curvob.hide_set(False)


### PR DESCRIPTION
When you have an object which was deleted/joined, and are using a collection, it would give you an error if in collection mode as it tried to access a non-existant object, this adds a detection for collections, which seems to work. It unhides all of the objects in the collection (what the call was doing for objects.) 

Error before (very non-intuitive originally, first thing I tried was a new collection, which for reasons now obvious had the same error): 
    ob = bpy.data.objects[o.object_name]
KeyError: 'bpy_prop_collection[key]: key "Cube.001" not found'