### PR TITLE
fix `joinMultiple()` -> `join_multiple()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ config/bookmarks.txt
 *.pyc
 *.ocio
 *.spi3d
-*.py
 config/recent-files.txt
 scripts/addons_contrib/add_mesh_rocks/add_mesh_rocks.xml
 scripts/addons_contrib/online_mat_lib/material-library/bundled/cycles/wood/rough_pine.bcm

--- a/scripts/addons/cam/strategy.py
+++ b/scripts/addons/cam/strategy.py
@@ -466,7 +466,7 @@ def pocket(o):
         chunks = utils.sortChunks(chunks, o)
 
     if o.pocketToCurve:  # make curve instead of a path
-        simple.joinMultiple("3dpocket")
+        simple.join_multiple("3dpocket")
 
     else:
         chunksToMesh(chunks, o)  # make normal pocket path
@@ -743,7 +743,7 @@ def medial_axis(o):
         chunklayers = utils.sortChunks(chunklayers, o)
 
     if o.add_mesh_for_medial:  # make curve instead of a path
-        simple.joinMultiple("medialMesh")
+        simple.join_multiple("medialMesh")
 
     chunksToMesh(chunklayers, o)
     # add pocket operation for medial if add pocket checked


### PR DESCRIPTION
Recently I had to use `Strategy: Pocket` with `Pocket to curve` option and it gave me an error due to a rename from `simple.joinMultiple()` to `simple.join_multiple()` so this is a fix for that.

I also removed `*.py` from `.gitignore` so I can add the changes to the commit history.