### PR TITLE
Hotfix for: No module named 'shapely' issue #232

### DIFF
--- a/scripts/addons/cam/simple.py
+++ b/scripts/addons/cam/simple.py
@@ -19,6 +19,9 @@
 #
 # ***** END GPL LICENCE BLOCK *****
 
+# Solves: No module named 'shapely' (even if it is installed)
+help('modules')
+
 import math
 import sys
 import os


### PR DESCRIPTION
This change resolves issue #232 
I don't understand why it works, but it doesn't really change the code functionality in any way, it just prints all the modules to the terminal.