### PR TITLE
Fix import MultiLineString. Issue was detected with shapely 1.8.2 module

### DIFF
--- a/scripts/addons/cam/curvecamtools.py
+++ b/scripts/addons/cam/curvecamtools.py
@@ -179,7 +179,7 @@ class CamCurveOvercuts(bpy.types.Operator):
         for s in shapes.geoms:
             s = shapely.geometry.polygon.orient(s, 1)
             if s.boundary.geom_type == 'LineString':
-                from shapely import MultiLineString
+                from shapely.geometry import MultiLineString
                 loops = MultiLineString([s.boundary])
             else:
                 loops = s.boundary


### PR DESCRIPTION
Hello.
I got import error MultiLineString class when I tried to use overcut feature.
Here is simple code patch.
Please apply it.