### PR TITLE
Tested slow start grbl code with small cnc mill successfully.

### DIFF
--- a/scripts/addons/cam/post_processors/iso.py
+++ b/scripts/addons/cam/post_processors/iso.py
@@ -9,6 +9,7 @@ from . import nc
 import math
 from .format import Format
 from .format import *
+import bpy
 
 ################################################################################
 
@@ -688,8 +689,55 @@ class Creator(nc.Creator):
             # not much, if any horizontal component, so use the vertical feed rate
             self.f.set(self.fh)
 
-    def spindle(self, s, clockwise):
-        if clockwise == True:
+    # def spindle(self, s, clockwise):
+    #     if clockwise == True:
+    #         self.s.set(s, self.SPINDLE_CW(), self.SPINDLE_CCW())
+    #     else:
+    #         self.s.set(s, self.SPINDLE_CCW(), self.SPINDLE_CW())
+    def spindle(self, s, clockwise): # EXPERIMENTAL -- grbl only
+        # Get machine settings
+        machine = bpy.context.scene.cam_machine
+
+        if (machine.spindle_slow_start_enable and
+                s > machine.spindle_min + machine.spindle_slow_start_skip_threshold):
+
+            # Generate slow start sequence
+            steps = machine.spindle_slow_start_steps
+            total_time = machine.spindle_slow_start_total_time
+            step_time = total_time / steps
+
+            # Calculate speed increments
+            speed_range = s - machine.spindle_min
+            step_increment = speed_range / steps
+
+            # Start at minimum speed
+            current_speed = machine.spindle_min
+            if clockwise:
+                self.s.set(current_speed, self.SPINDLE_CW(), self.SPINDLE_CCW())
+            else:
+                self.s.set(current_speed, self.SPINDLE_CCW(), self.SPINDLE_CW())
+            self.write_spindle()
+
+            # Ramp up through intermediate steps
+            for step in range(1, steps + 1):
+                if step < steps:
+                    current_speed = machine.spindle_min + (step_increment * step)
+                else:
+                    current_speed = s  # Final target speed
+
+                # Dwell for step time
+                self.dwell(step_time)
+
+                # Set next speed
+                current_speed = int(current_speed)
+                if clockwise:
+                    self.s.set(current_speed, self.SPINDLE_CW(), self.SPINDLE_CCW())
+                else:
+                    self.s.set(current_speed, self.SPINDLE_CCW(), self.SPINDLE_CW())
+                self.write_spindle()
+        else:
+            # Normal spindle start (existing code)
+            if clockwise:
             self.s.set(s, self.SPINDLE_CW(), self.SPINDLE_CCW())
         else:
             self.s.set(s, self.SPINDLE_CCW(), self.SPINDLE_CW())

--- a/scripts/addons/cam/properties/machine_props.py
+++ b/scripts/addons/cam/properties/machine_props.py
@@ -208,6 +208,38 @@ class CAM_MACHINE_Properties(PropertyGroup):
         max=320000,
         precision=1,
     )
+
+    # Spindle Slow Start Settings
+    spindle_slow_start_enable: BoolProperty(
+        name="Spindle Slow Start Enable",
+        description="Enable gradual spindle speed ramping from minimum to target speed",
+        default=False,
+    )
+    spindle_slow_start_steps: IntProperty(
+        name="Slow Start Steps",
+        description="Number of intermediate speed steps when ramping from minimum to target spindle speed. More steps = smoother acceleration",
+        default=8,
+        min=2,
+        max=20,
+    )
+    spindle_slow_start_skip_threshold: FloatProperty(
+        name="Skip Threshold (RPM)",
+        description="If target speed is within this RPM of the minimum speed, skip slow start and go directly to target",
+        default=500,
+        min=0,
+        max=5000,
+        precision=0,
+    )
+
+    spindle_slow_start_total_time: FloatProperty(
+        name="Total Ramp Time (seconds)",
+        description="Total time in seconds to ramp from minimum to target speed, distributed equally across all steps",
+        default=2.0,
+        min=0.1,
+        max=10.0,
+        precision=1,
+    )
+
     axis_4: BoolProperty(
         name="4th Axis",
         description="Machine has 4th axis",

--- a/scripts/addons/cam/ui/panels/machine_panel.py
+++ b/scripts/addons/cam/ui/panels/machine_panel.py
@@ -93,6 +93,20 @@ class CAM_MACHINE_Panel(CAMParentPanel, Panel):
             col.prop(self.machine, "spindle_min", text="Minimum")
             col.prop(self.machine, "spindle_max", text="Maximum")
             panel.prop(self.machine, "spindle_start_time", text="Start Delay (seconds)")
+            # Spindle Slow Start
+            if self.level >= 2:
+                subheader, subpanel = panel.panel(idname="slow_start", default_closed=True)
+                subheader.label(text="Slow Start (Ramp-Up) (*EXPERIMENTAL, grbl only*)")
+                col = subpanel.column(align=True)
+                if subpanel:
+                    subpanel.use_property_split = True
+                    col.prop(self.machine, "spindle_slow_start_enable", text="Slow Start")
+                    subcol = col.column(align=True)
+                    subcol.enabled = self.machine.spindle_slow_start_enable
+                    subcol.prop(self.machine, "spindle_slow_start_steps", text="Steps")
+                    subcol.prop(self.machine, "spindle_slow_start_skip_threshold", text="Skip Small Increase (RPM)")
+                    subcol.prop(self.machine, "spindle_slow_start_total_time", text="Total Time (sec)")
+
 
         # Gcode Options
         if self.level >= 1:


### PR DESCRIPTION
This is to address a common issue with modern budget CNC mills where the inrush current can cause control board resets (or possibly PSU issues).

I'm not sure if my default of 2.0s spindle-speed works for me. I did not exhaustively test that time and it is quite likely the initial inrush happens much faster and 2s would "never" be necessary.

**Future improvements:**
*An RPM step size option.*
Currently I only have a step count.
Offering a `step size (in RPM)` would be nice.
To keep the UI simple, it would just internally calculate whichever is the finer increments and use it.