### PR TITLE
Fixing AddPresetCamOperation

### DIFF
--- a/scripts/addons/fabex/operators/preset_ops.py
+++ b/scripts/addons/fabex/operators/preset_ops.py
@@ -43,10 +43,10 @@ class AddPresetCamOperation(AddPresetBase, Operator):
 
     preset_defines = [
         "from pathlib import Path",
-        "bpy.ops.scene.cam_operation_add()",
+        # "bpy.ops.scene.cam_operation_add()",
         "scene = bpy.context.scene",
         "o = scene.cam_operations[scene.cam_active_operation]",
-        "o.name = f'OP_{o.object_name}_{scene.cam_active_operation + 1}_{Path(__file__).stem}'",
+        # "o.name = f'OP_{o.object_name}_{scene.cam_active_operation + 1}_{Path(__file__).stem}'",
     ]
 
     preset_values = [

--- a/scripts/addons/fabex/operators/preset_ops.py
+++ b/scripts/addons/fabex/operators/preset_ops.py
@@ -43,10 +43,10 @@ class AddPresetCamOperation(AddPresetBase, Operator):
 
     preset_defines = [
         "from pathlib import Path",
-        # "bpy.ops.scene.cam_operation_add()",
+        "if '__file__' in globals(): bpy.ops.scene.cam_operation_add()",
         "scene = bpy.context.scene",
         "o = scene.cam_operations[scene.cam_active_operation]",
-        # "o.name = f'OP_{o.object_name}_{scene.cam_active_operation + 1}_{Path(__file__).stem}'",
+        "if '__file__' in globals(): o.name = f'OP_{o.object_name}_{scene.cam_active_operation + 1}_{Path(__file__).stem}'",
     ]
 
     preset_values = [
@@ -117,10 +117,10 @@ class AddPresetCamOperation(AddPresetBase, Operator):
         "o.strategy",
         "o.update_z_buffer_image_tag",
         "o.stepdown",
-        "o.path_object_name",
+        # "o.path_object_name",
         "o.pencil_threshold",
         "o.geometry_source",
-        "o.object_name",
+        # "o.object_name",
         "o.parallel_angle",
         "o.output_header",
         "o.gcode_header",


### PR DESCRIPTION
Expectation:
- Clicking on the ADD (+) button should create a preset based on the current operation.

What happened instead:
- It created a new operation, and create a new preset based on that new operation
- It also raised a bug with "__file__ not defined"

This PR solution:
This fix checks if the operator is running from" Creating New Preset" or from "Using The Preset" with `if '__file__' in globals()`

Possible future solution: Preset should "change the current CAM operation settings", instead of working as a way to "create CAM operation from preset"

Sorry my first PR ever, idk if I did it right!! Awesome addon btw!