### PR TITLE
showing the skin option for ocl waterline

### DIFF
--- a/scripts/addons/fabex/ui/panels/op_properties_panel.py
+++ b/scripts/addons/fabex/ui/panels/op_properties_panel.py
@@ -107,6 +107,8 @@ class CAM_OPERATION_PROPERTIES_Panel(CAMParentPanel, Panel):
                 box = col.box()
                 box.alert = True
                 box.label(text="Ocl Doesn't Support Fill Areas", icon="ERROR")
+                # ocl waterline also takes skin into account
+                col.prop(self.op, "skin")
             else:
                 col.prop(self.op, "slice_detail", text="Slice Detail")
                 col.prop(self.op, "skin")


### PR DESCRIPTION
Currently the skin setting is hidden when you enable optimisation.use_opencamlib
But the strategy seems to take `skin` setting into account, so it should be shown?
